### PR TITLE
fix: big meaty ui fix

### DIFF
--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -421,16 +421,19 @@ export const Status = () => {
               <Text color='text.subtle'>Refund Address</Text>
             </Flex>
           </Flex>
-          <Flex alignItems='center' gap={2}>
-            <Text>{refundAddress || ''}</Text>
-            <IconButton
-              size='sm'
-              variant='ghost'
-              icon={isRefundAddressCopied ? checkIcon : copyIcon}
-              aria-label='Copy refund address'
-              onClick={handleCopyRefundAddress}
-            />
-          </Flex>
+          <InputGroup>
+            <Input isReadOnly value={refundAddress} />
+            <InputRightElement>
+              <IconButton
+                borderRadius='lg'
+                size='sm'
+                variant='ghost'
+                icon={isRefundAddressCopied ? checkIcon : copyIcon}
+                aria-label='Copy refund address'
+                onClick={handleCopyRefundAddress}
+              />
+            </InputRightElement>
+          </InputGroup>
         </Stack>
         <Stack>
           <Flex width='full' justifyContent='space-between'>
@@ -439,16 +442,19 @@ export const Status = () => {
               <Text color='text.subtle'>Receive Address</Text>
             </Flex>
           </Flex>
-          <Flex alignItems='center' gap={2}>
-            <Text>{destinationAddress || ''}</Text>
-            <IconButton
-              size='sm'
-              variant='ghost'
-              icon={isReceiveAddressCopied ? checkIcon : copyIcon}
-              aria-label='Copy receive address'
-              onClick={handleCopyReceiveAddress}
-            />
-          </Flex>
+          <InputGroup>
+            <Input isReadOnly value={destinationAddress} />
+            <InputRightElement>
+              <IconButton
+                borderRadius='lg'
+                size='sm'
+                variant='ghost'
+                icon={isReceiveAddressCopied ? checkIcon : copyIcon}
+                aria-label='Copy receive address'
+                onClick={handleCopyReceiveAddress}
+              />
+            </InputRightElement>
+          </InputGroup>
         </Stack>
         <Divider borderColor='border.base' />
         <Stack spacing={2}>


### PR DESCRIPTION
Makes long addies (and not-so-long ones on mobile) not broken-looking, and addies rows feel more integrated at that 🐦 🐦 🗿 

Before:

<img width="464" alt="Screenshot 2025-02-11 at 09 58 09" src="https://github.com/user-attachments/assets/5705a414-476f-496e-9199-3fc677130ac3" />
<img width="468" alt="image" src="https://github.com/user-attachments/assets/d470d3f9-717e-4050-8efd-0d93f73e2e0f" />


After:

<img width="436" alt="Screenshot 2025-02-11 at 09 58 02" src="https://github.com/user-attachments/assets/a15d1462-24e6-4b4e-9a64-dfe3683f123c" />
<img width="454" alt="image" src="https://github.com/user-attachments/assets/8e4b3709-991d-42ca-bc87-29af413815d7" />
