### PR TITLE
feat: add "do another swap" button after trade

### DIFF
--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -230,7 +230,7 @@ const PendingSwapCardBody = ({
                   Launch Shapeshift App
                 </Button>
                 <Button colorScheme='gray' size='md' onClick={handleDoAnotherSwap}>
-                  Do another swap
+                  Do Another Swap
                 </Button>
               </Flex>
             </VStack>

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -34,7 +34,7 @@ import { reactQueries } from 'queries/react-queries'
 import { useCallback, useMemo } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { FaArrowUpRightFromSquare, FaCheck, FaRegCopy } from 'react-icons/fa6'
-import { useSearchParams } from 'react-router'
+import { useNavigate, useSearchParams } from 'react-router'
 import { useAssetById } from 'store/assets'
 import { Amount } from 'components/Amount/Amount'
 import { QRCode } from 'components/QRCode/QRCode'
@@ -182,6 +182,7 @@ const PendingSwapCardBody = ({
     status: ChainflipSwapStatus
   }
 }) => {
+  const navigate = useNavigate()
   const config = getChainflipStatusConfig(swapStatus?.status.state, swapStatus)
   const StatusIcon = config.icon
   const isCompleted = swapStatus?.status.state === 'completed'
@@ -190,6 +191,10 @@ const PendingSwapCardBody = ({
   const handleLaunchApp = useCallback(() => {
     window.open('https://app.shapeshift.com', '_blank')
   }, [])
+
+  const handleDoAnotherSwap = useCallback(() => {
+    navigate('/')
+  }, [navigate])
 
   return (
     <CardBody height='full' display='flex' alignItems='center' justifyContent='center'>
@@ -220,9 +225,14 @@ const PendingSwapCardBody = ({
               <Text fontSize='md' color='gray.500'>
                 Do more with the ShapeShift platform
               </Text>
-              <Button colorScheme='blue' size='md' onClick={handleLaunchApp}>
-                Launch Shapeshift App
-              </Button>
+              <Flex gap={2}>
+                <Button colorScheme='blue' size='md' onClick={handleLaunchApp}>
+                  Launch Shapeshift App
+                </Button>
+                <Button colorScheme='gray' size='md' onClick={handleDoAnotherSwap}>
+                  Do another swap
+                </Button>
+              </Flex>
             </VStack>
           </SlideFade>
         )}


### PR DESCRIPTION
Does what it says on the box!

Does not reset any query params, as it's rather nice going back to the swap page and having it remember the assets you just traded, and all of your address info if you are going to do another trade.

<img width="569" alt="Screenshot 2025-02-12 at 18 20 51" src="https://github.com/user-attachments/assets/fd2d7384-acd7-49ab-8cd3-154f4ca73f8a" />

Want a completed swap to test with? Here, [use mine](http://localhost:3000/status?sellAssetId=eip155%3A42161%2Fslip44%3A60&buyAssetId=eip155%3A42161%2Ferc20%3A0xaf88d065e77c8cc2239327c5edb3a432268e5831&sellAmountCryptoBaseUnit=4000000000000000&refundAddress=0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6&destinationAddress=0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6&swapId=9012&channelId=36&depositAddress=0x39bf4dddb908dab260c8c5153b78cd967df6b2b1)!

Closes https://github.com/shapeshift/web/issues/8803