### PR TITLE
chore: improve rendered buy amount

### DIFF
--- a/src/components/TradeInput.tsx
+++ b/src/components/TradeInput.tsx
@@ -331,11 +331,11 @@ export const TradeInput = () => {
   const renderedBuyAmountCryptoPrecision = useMemo(() => {
     // No sell amount has been entered
     if (bnOrZero(sellAmountInput).eq(0)) return '0'
-    // We couldn't get a quote
-    if (!quote && !isQuoteFetching) return 'N/A'
+    // We have a quote error, most likely because of amount too high/low
+    if (quoteError) return 'N/A'
     // We have a quote, show the estimated buy amount
     return buyAmountCryptoPrecision
-  }, [buyAmountCryptoPrecision, sellAmountInput, quote, isQuoteFetching])
+  }, [buyAmountCryptoPrecision, sellAmountInput, quoteError])
 
   if (!(sellAsset && buyAsset)) return null
 

--- a/src/components/TradeInput.tsx
+++ b/src/components/TradeInput.tsx
@@ -328,6 +328,15 @@ export const TradeInput = () => {
 
   const isLoading = isQuoteFetching || isSwitching
 
+  const renderedBuyAmountCryptoPrecision = useMemo(() => {
+    // No sell amount has been entered
+    if (bnOrZero(sellAmountInput).eq(0)) return '0'
+    // We couldn't get a quote
+    if (!quote && !isQuoteFetching) return 'N/A'
+    // We have a quote, show the estimated buy amount
+    return buyAmountCryptoPrecision
+  }, [buyAmountCryptoPrecision, sellAmountInput, quote, isQuoteFetching])
+
   if (!(sellAsset && buyAsset)) return null
 
   return (
@@ -505,7 +514,7 @@ export const TradeInput = () => {
                     variant='filled'
                     placeholder={`0.0 ${buyAsset.symbol}`}
                     isReadOnly
-                    value={buyAmountCryptoPrecision || 'N/A'}
+                    value={renderedBuyAmountCryptoPrecision}
                     {...skeletonInputSx}
                   />
                   <Amount.Fiat value={buyAmountFiat} color='text.subtle' fontSize='sm' />


### PR DESCRIPTION
Improves logic for showing the expected buy amount.

No input:

<img width="355" alt="Screenshot 2025-02-12 at 18 44 43" src="https://github.com/user-attachments/assets/a4154cbd-646c-47e7-b1e0-c57fd1164f8d" />

No quote from input:

<img width="360" alt="Screenshot 2025-02-12 at 18 44 56" src="https://github.com/user-attachments/assets/2e35ead2-f3aa-41d0-9400-a36d1245bd76" />

Quote received:

<img width="359" alt="Screenshot 2025-02-12 at 18 44 50" src="https://github.com/user-attachments/assets/94ff29b4-49e5-4961-adc6-9dbf83af00af" />

Closes https://github.com/shapeshift/web/issues/8804