### PR TITLE
fix: no skeleton over amount input

### DIFF
--- a/src/components/TradeInput.tsx
+++ b/src/components/TradeInput.tsx
@@ -447,21 +447,40 @@ export const TradeInput = () => {
           </Flex>
           <Flex gap={6}>
             <Flex direction='column' width='50%'>
-              <NumericFormat
-                customInput={Input}
-                variant='filled'
-                placeholder={`Enter ${sellAsset.symbol} amount`}
-                value={sellAmountInput}
-                onValueChange={handleSellAmountChange}
-                allowNegative={false}
-                decimalScale={sellAsset.precision}
-                isInvalid={!!errors.sellAmountCryptoBaseUnit}
-              />
-              <Amount.Fiat value={sellAmountFiat} color='text.subtle' fontSize='sm' mt={1} />
-              {errors.sellAmountCryptoBaseUnit && (
-                <Text fontSize='sm' color='red.500' mt={1}>
-                  {errors.sellAmountCryptoBaseUnit.message}
-                </Text>
+              {isLoading && isSwitching ? (
+                <VStack width='full' spacing={1} align='stretch'>
+                  <Skeleton height='40px' width='full'>
+                    <Input
+                      variant='filled'
+                      placeholder={`Enter ${sellAsset.symbol} amount`}
+                      isReadOnly
+                      value=''
+                      {...skeletonInputSx}
+                    />
+                  </Skeleton>
+                  <Skeleton height='18px' width='80px'>
+                    <Amount.Fiat value='0' color='text.subtle' fontSize='sm' />
+                  </Skeleton>
+                </VStack>
+              ) : (
+                <>
+                  <NumericFormat
+                    customInput={Input}
+                    variant='filled'
+                    placeholder={`Enter ${sellAsset.symbol} amount`}
+                    value={sellAmountInput}
+                    onValueChange={handleSellAmountChange}
+                    allowNegative={false}
+                    decimalScale={sellAsset.precision}
+                    isInvalid={!!errors.sellAmountCryptoBaseUnit}
+                  />
+                  <Amount.Fiat value={sellAmountFiat} color='text.subtle' fontSize='sm' mt={1} />
+                  {errors.sellAmountCryptoBaseUnit && (
+                    <Text fontSize='sm' color='red.500' mt={1}>
+                      {errors.sellAmountCryptoBaseUnit.message}
+                    </Text>
+                  )}
+                </>
               )}
             </Flex>
             <Flex direction='column' width='50%'>

--- a/src/components/TradeInput.tsx
+++ b/src/components/TradeInput.tsx
@@ -447,40 +447,21 @@ export const TradeInput = () => {
           </Flex>
           <Flex gap={6}>
             <Flex direction='column' width='50%'>
-              {isLoading ? (
-                <VStack width='full' spacing={1} align='stretch'>
-                  <Skeleton height='40px' width='full'>
-                    <Input
-                      variant='filled'
-                      placeholder={`Enter ${sellAsset.symbol} amount`}
-                      isReadOnly
-                      value=''
-                      {...skeletonInputSx}
-                    />
-                  </Skeleton>
-                  <Skeleton height='18px' width='80px'>
-                    <Amount.Fiat value='0' color='text.subtle' fontSize='sm' />
-                  </Skeleton>
-                </VStack>
-              ) : (
-                <>
-                  <NumericFormat
-                    customInput={Input}
-                    variant='filled'
-                    placeholder={`Enter ${sellAsset.symbol} amount`}
-                    value={sellAmountInput}
-                    onValueChange={handleSellAmountChange}
-                    allowNegative={false}
-                    decimalScale={sellAsset.precision}
-                    isInvalid={!!errors.sellAmountCryptoBaseUnit}
-                  />
-                  <Amount.Fiat value={sellAmountFiat} color='text.subtle' fontSize='sm' mt={1} />
-                  {errors.sellAmountCryptoBaseUnit && (
-                    <Text fontSize='sm' color='red.500' mt={1}>
-                      {errors.sellAmountCryptoBaseUnit.message}
-                    </Text>
-                  )}
-                </>
+              <NumericFormat
+                customInput={Input}
+                variant='filled'
+                placeholder={`Enter ${sellAsset.symbol} amount`}
+                value={sellAmountInput}
+                onValueChange={handleSellAmountChange}
+                allowNegative={false}
+                decimalScale={sellAsset.precision}
+                isInvalid={!!errors.sellAmountCryptoBaseUnit}
+              />
+              <Amount.Fiat value={sellAmountFiat} color='text.subtle' fontSize='sm' mt={1} />
+              {errors.sellAmountCryptoBaseUnit && (
+                <Text fontSize='sm' color='red.500' mt={1}>
+                  {errors.sellAmountCryptoBaseUnit.message}
+                </Text>
               )}
             </Flex>
             <Flex direction='column' width='50%'>


### PR DESCRIPTION
@gomesalexandre after playing with https://github.com/shapeshift/og/pull/51 a bit more it's actually super ruggy and annoying when inputting an amount.

We should only show the skeleton over the amount input on asset switch.