### PR TITLE
polish: don't animate complete progress bar

### DIFF
--- a/src/components/Status/components/StatusStepper.tsx
+++ b/src/components/Status/components/StatusStepper.tsx
@@ -56,8 +56,8 @@ export const StatusStepper = ({
       borderColor='border.base'
     >
       <Progress
-        isAnimated
-        hasStripe
+        isAnimated={progress !== 100}
+        hasStripe={progress !== 100}
         value={progress}
         size='sm'
         colorScheme={colorScheme}


### PR DESCRIPTION
Precisely what it says on the box:

<img width="476" alt="image" src="https://github.com/user-attachments/assets/772d8ee8-5e06-40e6-aa8f-8799bbd6be18" />

Test me by making an actual swap or with e.g `/status?sellAssetId=eip155%3A42161%2Ferc20%3A0xaf88d065e77c8cc2239327c5edb3a432268e5831&buyAssetId=eip155%3A42161%2Fslip44%3A60&sellAmountCryptoBaseUnit=13545580&destinationAddress=0x5daF465a9cCf64DEB146eEaE9E7Bd40d6761c986&refundAddress=0x5daF465a9cCf64DEB146eEaE9E7Bd40d6761c986&swapId=9260&channelId=214&depositAddress=0xf0d257e35c8eed11fc81f15dc450e1a408b27cd5`