### PR TITLE
chore: only show rate refresh countdown on amount input

### DIFF
--- a/src/components/TradeInput.tsx
+++ b/src/components/TradeInput.tsx
@@ -380,12 +380,14 @@ export const TradeInput = () => {
                 </Flex>
               </>
             ) : null}
-            <Box position='absolute' right='4' top='50%' transform='translateY(-50%)'>
-              <CountdownSpinner
-                isLoading={isQuoteFetching}
-                initialTimeMs={QUOTE_REFETCH_INTERVAL}
-              />
-            </Box>
+            {bnOrZero(sellAmountInput).gt(0) && (
+              <Box position='absolute' right='4' top='50%' transform='translateY(-50%)'>
+                <CountdownSpinner
+                  isLoading={isQuoteFetching}
+                  initialTimeMs={QUOTE_REFETCH_INTERVAL}
+                />
+              </Box>
+            )}
           </Flex>
           <HStack divider={divider} fontSize='sm'>
             <Stat size='sm' textAlign='center' py={4}>


### PR DESCRIPTION
Only show the quote refresh spinner if the user has an amount entered.

Closes https://github.com/shapeshift/og/issues/64

https://jam.dev/c/f93379f8-ee78-4912-b91e-2af536585994