### PR TITLE
chore: do not show fee rows

### DIFF
--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -29,7 +29,7 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 import { chainflipToAssetId, getChainflipId } from 'queries/chainflip/assets'
 import { useChainflipQuoteQuery } from 'queries/chainflip/quote'
 import { useChainflipStatusQuery } from 'queries/chainflip/status'
-import type { ChainflipQuote, ChainflipSwapStatus } from 'queries/chainflip/types'
+import type { ChainflipSwapStatus } from 'queries/chainflip/types'
 import { reactQueries } from 'queries/react-queries'
 import { useCallback, useMemo } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
@@ -64,14 +64,6 @@ const cardHeaderSx = {
   borderTopRadius: 'xl',
   fontSize: 'sm',
   py: 2,
-}
-
-const calculateShapeshiftFee = (quote: ChainflipQuote | undefined) => {
-  if (!quote?.includedFees) return '0'
-
-  const brokerFee = quote.includedFees.find(fee => fee.type === 'broker')
-
-  return bnOrZero(brokerFee?.amount).toFixed(2)
 }
 
 const IdleSwapCardBody = ({
@@ -490,14 +482,6 @@ export const Status = () => {
               />
             </Flex>
           </Flex>
-          <HStack justify='space-between'>
-            <Text color='text.subtle'>ShapeShift Fee</Text>
-            <Amount.Fiat value={calculateShapeshiftFee(quote)} />
-          </HStack>
-          <HStack justify='space-between'>
-            <Text color='text.subtle'>Protocol Fee</Text>
-            <Amount.Fiat value={protocolFeesFiat} />
-          </HStack>
         </Stack>
       </CardFooter>
     </Card>


### PR DESCRIPTION
Removes the fee rows, as there are already included in the rate shown to the user.

Further, they are already included in the "Estimated Receive" amount - showing them only serves to clutter the UI and make the trade experience feel worse (opinion).

Closes https://github.com/shapeshift/og/issues/61

This branch:

<img width="369" alt="Screenshot 2025-02-13 at 15 09 48" src="https://github.com/user-attachments/assets/f7e17c08-b540-463b-a9b6-816f2fd84b77" />

`develop`:

<img width="351" alt="Screenshot 2025-02-13 at 15 10 14" src="https://github.com/user-attachments/assets/3da9ce9e-20b2-4203-a230-4bd6a4806681" />
