### PR TITLE
fix: ensure swapId is truthy before displaying Tx link

### DIFF
--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -207,7 +207,7 @@ const PendingSwapCardBody = ({
               {config.message}
             </Text>
           </SlideFade>
-          {swapStatus?.status.state !== 'waiting' && (
+          {swapStatus?.status.state !== 'waiting' && swapStatus?.status.swapId && (
             <Link
               href={`${CHAINFLIP_EXPLORER_BASE_URL}/swaps/${swapStatus?.status.swapId}`}
               isExternal


### PR DESCRIPTION
Untested because of lack of funds to test the exact scenario triggering this (most likely happening on ETH sells) but fix is fairly straightforward.