### PR TITLE
feat: add success and buttons mixpanel events

### DIFF
--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -31,7 +31,7 @@ import { getChainflipId } from 'queries/chainflip/assets'
 import { useChainflipQuoteQuery } from 'queries/chainflip/quote'
 import { useChainflipStatusQuery } from 'queries/chainflip/status'
 import type { ChainflipSwapStatus } from 'queries/chainflip/types'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { FaArrowUpRightFromSquare, FaCheck, FaRegCopy } from 'react-icons/fa6'
 import { useNavigate, useSearchParams } from 'react-router'
@@ -39,6 +39,7 @@ import { useAssetById } from 'store/assets'
 import { Amount } from 'components/Amount/Amount'
 import { QRCode } from 'components/QRCode/QRCode'
 import { fromBaseUnit } from 'lib/bignumber/bignumber'
+import { mixpanel, MixPanelEvent } from 'lib/mixpanel'
 import { getChainflipStatusConfig } from 'lib/utils/chainflip'
 import type { SwapFormData } from 'types/form'
 
@@ -186,12 +187,22 @@ const PendingSwapCardBody = ({
   const StatusIcon = config.icon
   const isCompleted = swapStatus?.status.state === 'completed'
   const isRefunded = Boolean(swapStatus?.status.refundEgress) && isCompleted
+  const hasSentMixpanelEvent = useRef(false)
+
+  useEffect(() => {
+    if (isCompleted && !hasSentMixpanelEvent.current) {
+      mixpanel?.track(MixPanelEvent.SwapCompleted)
+      hasSentMixpanelEvent.current = true
+    }
+  }, [isCompleted])
 
   const handleLaunchApp = useCallback(() => {
+    mixpanel?.track(MixPanelEvent.LaunchShapeshiftApp)
     window.open('https://app.shapeshift.com', '_blank')
   }, [])
 
   const handleDoAnotherSwap = useCallback(() => {
+    mixpanel?.track(MixPanelEvent.DoAnotherSwap)
     navigate('/')
   }, [navigate])
 

--- a/src/lib/mixpanel/types.ts
+++ b/src/lib/mixpanel/types.ts
@@ -5,4 +5,7 @@ export type MixPanelType = typeof Mixpanel
 export enum MixPanelEvent {
   PairSelected = 'Pair Selected',
   StartTransaction = 'Start Transaction',
+  SwapCompleted = 'Swap Completed',
+  DoAnotherSwap = 'Do Another Swap',
+  LaunchShapeshiftApp = 'Launch Shapeshift App',
 }


### PR DESCRIPTION
closes #80 

Added success screen mixpanel event and button clicks mixpanel events

Althought LaunchShapeShiftApp was not a part of the ticket, I feel like it's super important to know how much users we redirect to shapeshift through OG, decided to be pragmatic and add this event too

I don't have access to the OG projects on mixpanel, so I didn't test E2E