### PR TITLE
feat: improve mixpanel reporting

### DIFF
--- a/src/components/SelectPair.tsx
+++ b/src/components/SelectPair.tsx
@@ -1,4 +1,5 @@
 import { Button, Card, CardBody, Flex, Heading, IconButton, useDisclosure } from '@chakra-ui/react'
+import { getChainflipId } from 'queries/chainflip/assets'
 import { useCallback, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { FaArrowRightArrowLeft } from 'react-icons/fa6'
@@ -30,8 +31,8 @@ export const SelectPair = () => {
     if (!(sellAsset && buyAsset)) return
 
     mixpanel?.track(MixPanelEvent.PairSelected, {
-      sellAsset,
-      buyAsset,
+      sourceAsset: getChainflipId(sellAsset.assetId),
+      destinationAsset: getChainflipId(buyAsset.assetId),
     })
 
     navigate('/input')

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -192,7 +192,7 @@ const PendingSwapCardBody = ({
   const StatusIcon = config.icon
   const isCompleted = swapStatus?.status.state === 'completed'
   const isRefunded = Boolean(swapStatus?.status.refundEgress) && isCompleted
-  const hasSentMixpanelEvent = useRef(false)
+  const hasSentMixpanelSwapCompletedEvent = useRef(false)
   const { control } = useFormContext<SwapFormData>()
 
   const sellAssetId = useWatch({ control, name: 'sellAssetId' })
@@ -224,7 +224,7 @@ const PendingSwapCardBody = ({
   }, [buyAmountCryptoPrecision, buyAssetMarketData?.price])
 
   useEffect(() => {
-    if (isCompleted && !hasSentMixpanelEvent.current) {
+    if (isCompleted && !hasSentMixpanelSwapCompletedEvent.current) {
       mixpanel?.track(MixPanelEvent.SwapCompleted, {
         sourceAsset,
         destinationAsset,
@@ -233,7 +233,7 @@ const PendingSwapCardBody = ({
         buyAmountCryptoPrecision,
         buyAmountFiat,
       })
-      hasSentMixpanelEvent.current = true
+      hasSentMixpanelSwapCompletedEvent.current = true
     }
   }, [
     buyAmountCryptoPrecision,

--- a/src/components/TradeInput.tsx
+++ b/src/components/TradeInput.tsx
@@ -192,15 +192,25 @@ export const TradeInput = () => {
         .times(bn(1).minus(slippageTolerancePercentageDecimal))
         .toFixed(buyAsset.precision)
 
+      const sourceAsset = getChainflipId(sellAsset.assetId)
+      const destinationAsset = getChainflipId(buyAsset.assetId)
+
       const createSwapPayload = {
-        sourceAsset: getChainflipId(sellAsset.assetId),
-        destinationAsset: getChainflipId(buyAsset.assetId),
+        sourceAsset,
+        destinationAsset,
         destinationAddress: destinationAddress || '',
         refundAddress: refundAddress || '',
         minimumPrice: minimumRate,
       }
 
-      mixpanel?.track(MixPanelEvent.StartTransaction, createSwapPayload)
+      mixpanel?.track(MixPanelEvent.StartTransaction, {
+        sourceAsset,
+        destinationAsset,
+        sellAmountCryptoPrecision,
+        sellAmountFiat,
+        buyAmountCryptoPrecision,
+        buyAmountFiat,
+      })
 
       createSwap(createSwapPayload)
     },
@@ -208,11 +218,13 @@ export const TradeInput = () => {
       quote,
       sellAsset,
       buyAsset,
-      destinationAddress,
-      refundAddress,
-      createSwap,
       buyAmountCryptoPrecision,
       sellAmountCryptoPrecision,
+      destinationAddress,
+      refundAddress,
+      sellAmountFiat,
+      buyAmountFiat,
+      createSwap,
     ],
   )
 


### PR DESCRIPTION
### Description

- standardises sourceAsset/destinationAsset terminology across the line
- ensure source and destination asset are actually human-readable, not an ugly `Asset` JSON which none of product/marketing can parse
- ensures that the `StartTransaction`:
  - does not contain PII (it's on-chain but hey)
  - has crypto/fiat amounts for analytics thingies
- ensures that the `SwapCompleted` has properties vs. empty previously, effectively the same ones as `StartTransaction` 

### Before

<img width="1458" alt="Screenshot 2025-03-11 at 20 55 06" src="https://github.com/user-attachments/assets/0a764d8d-a3bc-404f-a447-2ec732989e13" />

### After

<img width="1423" alt="Screenshot 2025-03-11 at 21 07 56" src="https://github.com/user-attachments/assets/8f1524e3-c940-488e-bb43-56ff65de26e1" />
