### PR TITLE
feat: add retryDurationInBlocks /swap param

### DIFF
--- a/src/components/TradeInput.tsx
+++ b/src/components/TradeInput.tsx
@@ -228,6 +228,7 @@ export const TradeInput = () => {
         destinationAddress: destinationAddress || '',
         refundAddress: refundAddress || '',
         minimumPrice: minimumRate,
+        retryDurationInBlocks: 150,
       }
 
       mixpanel?.track(MixPanelEvent.StartTransaction, {


### PR DESCRIPTION
### Description

Add required parameter or o.g will break tomorrow

> With the upcoming 1.8 release of Chainflip, Fill or Kill parameters (`refundAddress`, minimumPrice and `retryDurationInBlocks`) will be mandatory! We have reached out to most integrators before to make sure they have already implemented this. If you forget to pass these in, you will receive a clear API error.

This release is currently planned for Tuesday 18th March.

### Testing

- Ensure /swap requests go through

### Screenshots

https://jam.dev/c/b67bd933-61c6-42a1-964b-c9f340fcca83