### PR TITLE
feat: improve address display and mobile responsiveness

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -40,7 +40,7 @@ const motionWrapperSx = {
 
 const swapperWrapperSx = {
   ...motionWrapperSx,
-  maxWidth: '450px',
+  maxWidth: '560px',
 }
 
 const chatwootBoxProps = {

--- a/src/components/SelectPair.tsx
+++ b/src/components/SelectPair.tsx
@@ -79,7 +79,7 @@ export const SelectPair = () => {
   }, [sellAssetId, buyAssetId, setValue])
 
   return (
-    <Card width='full' maxWidth='450px'>
+    <Card width='full' maxWidth='560px'>
       <CardBody display='flex' flexDir='column' gap={8}>
         <Heading as='h4' fontSize='md' textAlign='center'>
           Choose which assets to trade

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -95,27 +95,28 @@ const AddressInput = ({
       borderWidth={2}
       borderColor='border.input'
       borderRadius='xl'
-      px={4}
     >
       {isExpanded ? (
-        <Text flex={1} py={2} wordBreak='break-all' fontFamily='mono'>
+        <Text flex={1} py={2} pl={4} wordBreak='break-all' fontFamily='mono' minWidth={0}>
           {address}
         </Text>
       ) : (
-        <Text flex={1} py={2} whiteSpace='nowrap' fontFamily='mono'>
+        <Text flex={1} py={2} pl={4} whiteSpace='nowrap' fontFamily='mono' minWidth={0}>
           {truncated}
         </Text>
       )}
-      {canTruncate && (
-        <IconButton
-          size='sm'
-          variant='ghost'
-          aria-label={isExpanded ? 'Collapse address' : 'Expand address'}
-          icon={isExpanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
-          onClick={handleToggle}
-        />
-      )}
-      <CopyButton text={address} ariaLabel={ariaLabel} />
+      <Flex alignItems='center' flexShrink={0}>
+        {canTruncate && (
+          <IconButton
+            size='sm'
+            variant='ghost'
+            aria-label={isExpanded ? 'Collapse address' : 'Expand address'}
+            icon={isExpanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
+            onClick={handleToggle}
+          />
+        )}
+        <CopyButton text={address} ariaLabel={ariaLabel} />
+      </Flex>
     </Flex>
   )
 }
@@ -151,7 +152,6 @@ const IdleSwapCardBody = ({
       // eslint-disable-next-line react-memo/require-usememo
       flexDir={{ base: 'column-reverse', md: 'row-reverse' }}
       gap={6}
-      px={4}
     >
       <Flex
         flexDir='column'
@@ -182,7 +182,7 @@ const IdleSwapCardBody = ({
           })()}
         </Tag>
       </Flex>
-      <Stack spacing={4} flex={1}>
+      <Stack spacing={4} flex={1} minWidth={0}>
         <Stack>
           <Text color='text.subtle'>Send</Text>
           <Flex alignItems='center' gap={2}>
@@ -215,7 +215,7 @@ const IdleSwapCardBody = ({
         <Stack>
           <Text color='text.subtle'>You will receive</Text>
           <Flex gap={2} alignItems='center'>
-            <AssetIcon assetId={buyAssetId} size='xs' />
+            <AssetIcon assetId={buyAssetId} size='sm' />
             <VStack spacing={0} alignItems='flex-start'>
               <Amount.Crypto value={buyAmountCryptoPrecision || '0'} symbol={buyAsset.symbol} />
               {buyAsset.relatedAssetKey && (
@@ -451,8 +451,8 @@ export const Status = () => {
           />
         </SlideFade>
         {!swapStatus?.status.depositChannel?.isExpired && !shouldDisplayPendingSwapBody && (
-          <Center>
-            <Alert status='info' mb={6} width='95%' borderRadius='lg'>
+          <Center px={6}>
+            <Alert status='info' mb={6} borderRadius='lg'>
               <AlertIcon boxSize={5} />
               <Text fontSize='sm'>
                 Send {sellAmountCryptoPrecision} {sellAsset.symbol} from any wallet to the address
@@ -479,15 +479,15 @@ export const Status = () => {
       <CardFooter
         flexDir='column'
         gap={4}
-        px={4}
+        px={6}
         bg='background.surface.raised.base'
         borderBottomRadius='xl'
       >
         <Text fontWeight='bold'>Order Details</Text>
-        <Stack>
+        <Stack spacing={4}>
           <Flex width='full' justifyContent='space-between'>
             <Flex alignItems='center' gap={2}>
-              <AssetIcon assetId={sellAssetId} size='xs' />
+              <AssetIcon assetId={sellAssetId} size='sm' />
               <Text color='text.subtle'>Refund Address</Text>
             </Flex>
           </Flex>
@@ -498,10 +498,10 @@ export const Status = () => {
             ariaLabel='Copy refund address'
           />
         </Stack>
-        <Stack>
+        <Stack spacing={4}>
           <Flex width='full' justifyContent='space-between'>
             <Flex alignItems='center' gap={2}>
-              <AssetIcon assetId={buyAssetId} size='xs' />
+              <AssetIcon assetId={buyAssetId} size='sm' />
               <Text color='text.subtle'>Receive Address</Text>
             </Flex>
           </Flex>

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -79,15 +79,14 @@ const AddressInput = ({
   const resolvedMinTruncationLength =
     useBreakpointValue(
       typeof minTruncationLength === 'number' ? { base: minTruncationLength } : minTruncationLength,
-    ) ?? (typeof minTruncationLength === 'number' ? minTruncationLength : 0)
+    ) ?? (typeof minTruncationLength === 'number' ? minTruncationLength : address.length)
 
   const visibleChars = Math.max(0, resolvedMinTruncationLength - 1)
   const headLength = Math.ceil((visibleChars * 4) / 7)
   const tailLength = visibleChars - headLength
   const canTruncate = address.length > resolvedMinTruncationLength
-  const truncated = canTruncate
-    ? `${address.slice(0, headLength)}…${address.slice(-tailLength)}`
-    : address
+  const tail = tailLength > 0 ? address.slice(-tailLength) : ''
+  const truncated = canTruncate ? `${address.slice(0, headLength)}…${tail}` : address
 
   return (
     <Flex
@@ -493,7 +492,7 @@ export const Status = () => {
             </Flex>
           </Flex>
           <AddressInput
-            address={refundAddress}
+            address={refundAddress ?? ''}
             // eslint-disable-next-line react-memo/require-usememo
             minTruncationLength={{ base: 16, md: 44 }}
             ariaLabel='Copy refund address'
@@ -507,7 +506,7 @@ export const Status = () => {
             </Flex>
           </Flex>
           <AddressInput
-            address={destinationAddress}
+            address={destinationAddress ?? ''}
             // eslint-disable-next-line react-memo/require-usememo
             minTruncationLength={{ base: 16, md: 44 }}
             ariaLabel='Copy receive address'

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -1,3 +1,4 @@
+import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons'
 import {
   Alert,
   AlertIcon,
@@ -11,14 +12,13 @@ import {
   Circle,
   Divider,
   Flex,
-  Input,
-  InputGroup,
-  InputRightElement,
+  IconButton,
   Link,
   SlideFade,
   Stack,
   Tag,
   Text,
+  useBreakpointValue,
   VStack,
 } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
@@ -30,7 +30,7 @@ import { useChainflipQuoteQuery } from 'queries/chainflip/quote'
 import { useChainflipStatusQuery } from 'queries/chainflip/status'
 import type { ChainflipSwapStatus } from 'queries/chainflip/types'
 import { useMarketDataByAssetIdQuery } from 'queries/marketData'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { FaArrowUpRightFromSquare } from 'react-icons/fa6'
 import { useNavigate, useSearchParams } from 'react-router'
@@ -64,6 +64,63 @@ const cardHeaderSx = {
   py: 2,
 }
 
+const AddressInput = ({
+  address,
+  ariaLabel,
+  minTruncationLength,
+}: {
+  address: string
+  ariaLabel: string
+  minTruncationLength: number | Partial<Record<'base' | 'sm' | 'md' | 'lg' | 'xl', number>>
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const handleToggle = useCallback(() => setIsExpanded(prev => !prev), [])
+
+  const resolvedMinTruncationLength =
+    useBreakpointValue(
+      typeof minTruncationLength === 'number' ? { base: minTruncationLength } : minTruncationLength,
+    ) ?? (typeof minTruncationLength === 'number' ? minTruncationLength : 0)
+
+  const visibleChars = Math.max(0, resolvedMinTruncationLength - 1)
+  const headLength = Math.ceil((visibleChars * 4) / 7)
+  const tailLength = visibleChars - headLength
+  const canTruncate = address.length > resolvedMinTruncationLength
+  const truncated = canTruncate
+    ? `${address.slice(0, headLength)}…${address.slice(-tailLength)}`
+    : address
+
+  return (
+    <Flex
+      alignItems='center'
+      bg='background.input.base'
+      borderWidth={2}
+      borderColor='border.input'
+      borderRadius='xl'
+      px={4}
+    >
+      {isExpanded ? (
+        <Text flex={1} py={2} wordBreak='break-all' fontFamily='mono'>
+          {address}
+        </Text>
+      ) : (
+        <Text flex={1} py={2} whiteSpace='nowrap' fontFamily='mono'>
+          {truncated}
+        </Text>
+      )}
+      {canTruncate && (
+        <IconButton
+          size='sm'
+          variant='ghost'
+          aria-label={isExpanded ? 'Collapse address' : 'Expand address'}
+          icon={isExpanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
+          onClick={handleToggle}
+        />
+      )}
+      <CopyButton text={address} ariaLabel={ariaLabel} />
+    </Flex>
+  )
+}
+
 const IdleSwapCardBody = ({
   swapData,
   sellAssetId,
@@ -90,8 +147,13 @@ const IdleSwapCardBody = ({
   if (!(sellAsset && buyAsset)) return null
 
   return (
-    <CardBody display='flex' flexDir='row-reverse' gap={6} px={4}>
-      <Flex flexDir='column' gap={4}>
+    <CardBody
+      display='flex'
+      flexDir={{ base: 'column-reverse', md: 'row-reverse' }}
+      gap={6}
+      px={4}
+    >
+      <Flex flexDir='column' gap={4} alignItems={{ base: 'center', md: 'stretch' }}>
         {!isExpired && (
           <Box bg='white' p={4} borderRadius='xl'>
             <QRCode content={swapData.address || ''} width={150} icon={qrCodeIcon} />
@@ -136,12 +198,11 @@ const IdleSwapCardBody = ({
         {!isExpired && (
           <Stack>
             <Text color='text.subtle'>To</Text>
-            <InputGroup>
-              <Input isReadOnly value={swapData.address || ''} />
-              <InputRightElement>
-                <CopyButton text={swapData.address} ariaLabel='Copy address' />
-              </InputRightElement>
-            </InputGroup>
+            <AddressInput
+              address={swapData.address || ''}
+              minTruncationLength={{ base: 16, md: 23 }}
+              ariaLabel='Copy address'
+            />
           </Stack>
         )}
         <Divider borderColor='border.base' />
@@ -351,7 +412,7 @@ export const Status = () => {
   if (!(sellAsset && buyAsset)) return null
 
   return (
-    <Card width='full' maxW='465px'>
+    <Card width='full' maxW='560px'>
       <CardHeader {...cardHeaderSx}>
         <Text color='text.subtle'>Channel ID:</Text>
         {swapData.channelId && (
@@ -424,12 +485,11 @@ export const Status = () => {
               <Text color='text.subtle'>Refund Address</Text>
             </Flex>
           </Flex>
-          <InputGroup>
-            <Input isReadOnly value={refundAddress} />
-            <InputRightElement>
-              <CopyButton text={refundAddress} ariaLabel='Copy refund address' />
-            </InputRightElement>
-          </InputGroup>
+          <AddressInput
+            address={refundAddress}
+            minTruncationLength={{ base: 16, md: 44 }}
+            ariaLabel='Copy refund address'
+          />
         </Stack>
         <Stack>
           <Flex width='full' justifyContent='space-between'>
@@ -438,12 +498,11 @@ export const Status = () => {
               <Text color='text.subtle'>Receive Address</Text>
             </Flex>
           </Flex>
-          <InputGroup>
-            <Input isReadOnly value={destinationAddress} />
-            <InputRightElement>
-              <CopyButton text={destinationAddress} ariaLabel='Copy receive address' />
-            </InputRightElement>
-          </InputGroup>
+          <AddressInput
+            address={destinationAddress}
+            minTruncationLength={{ base: 16, md: 44 }}
+            ariaLabel='Copy receive address'
+          />
         </Stack>
         <Divider borderColor='border.base' />
         <Stack spacing={2}>

--- a/src/components/Status/Status.tsx
+++ b/src/components/Status/Status.tsx
@@ -149,11 +149,17 @@ const IdleSwapCardBody = ({
   return (
     <CardBody
       display='flex'
+      // eslint-disable-next-line react-memo/require-usememo
       flexDir={{ base: 'column-reverse', md: 'row-reverse' }}
       gap={6}
       px={4}
     >
-      <Flex flexDir='column' gap={4} alignItems={{ base: 'center', md: 'stretch' }}>
+      <Flex
+        flexDir='column'
+        gap={4}
+        // eslint-disable-next-line react-memo/require-usememo
+        alignItems={{ base: 'center', md: 'stretch' }}
+      >
         {!isExpired && (
           <Box bg='white' p={4} borderRadius='xl'>
             <QRCode content={swapData.address || ''} width={150} icon={qrCodeIcon} />
@@ -200,6 +206,7 @@ const IdleSwapCardBody = ({
             <Text color='text.subtle'>To</Text>
             <AddressInput
               address={swapData.address || ''}
+              // eslint-disable-next-line react-memo/require-usememo
               minTruncationLength={{ base: 16, md: 23 }}
               ariaLabel='Copy address'
             />
@@ -487,6 +494,7 @@ export const Status = () => {
           </Flex>
           <AddressInput
             address={refundAddress}
+            // eslint-disable-next-line react-memo/require-usememo
             minTruncationLength={{ base: 16, md: 44 }}
             ariaLabel='Copy refund address'
           />
@@ -500,6 +508,7 @@ export const Status = () => {
           </Flex>
           <AddressInput
             address={destinationAddress}
+            // eslint-disable-next-line react-memo/require-usememo
             minTruncationLength={{ base: 16, md: 44 }}
             ariaLabel='Copy receive address'
           />

--- a/src/components/Status/components/StatusStepper.tsx
+++ b/src/components/Status/components/StatusStepper.tsx
@@ -50,8 +50,9 @@ export const StatusStepper = ({
     <Flex
       bg='background.surface.raised.base'
       px={4}
+      py={4}
       flexDir='column'
-      gap={4}
+      justifyContent='center'
       borderBottomWidth={1}
       borderColor='border.base'
     >
@@ -63,7 +64,6 @@ export const StatusStepper = ({
         colorScheme={colorScheme}
         bg='gray.100'
         borderRadius='full'
-        mb={4}
       />
       <Flex gap={4} justify='space-between'></Flex>
     </Flex>

--- a/src/components/TradeInput.tsx
+++ b/src/components/TradeInput.tsx
@@ -57,6 +57,8 @@ const skeletonInputSx = {
   _focus: { bg: 'background.surface.raised.base' },
 }
 
+const placeholderSx = { fontFamily: 'body' }
+
 export const TradeInput = () => {
   const navigate = useNavigate()
   const {
@@ -699,6 +701,7 @@ export const TradeInput = () => {
                 required
                 title='Please enter a valid destination address'
                 fontFamily='mono'
+                _placeholder={placeholderSx}
               />
               <InputRightElement>
                 <IconButton
@@ -728,6 +731,7 @@ export const TradeInput = () => {
                 required
                 title='Please enter a valid refund address'
                 fontFamily='mono'
+                _placeholder={placeholderSx}
               />
               <InputRightElement>
                 <IconButton

--- a/src/components/TradeInput.tsx
+++ b/src/components/TradeInput.tsx
@@ -487,7 +487,7 @@ export const TradeInput = () => {
 
   return (
     <>
-      <Card width='full' maxWidth='450px' overflow='hidden' as='form' onSubmit={handleSubmit}>
+      <Card width='full' maxWidth='560px' overflow='hidden' as='form' onSubmit={handleSubmit}>
         <CardHeader px={0} py={0} bg='background.surface.raised.base'>
           <Flex
             fontSize='sm'
@@ -698,6 +698,7 @@ export const TradeInput = () => {
                 isInvalid={!!errors.destinationAddress}
                 required
                 title='Please enter a valid destination address'
+                fontFamily='mono'
               />
               <InputRightElement>
                 <IconButton
@@ -726,6 +727,7 @@ export const TradeInput = () => {
                 isInvalid={!!errors.refundAddress}
                 required
                 title='Please enter a valid refund address'
+                fontFamily='mono'
               />
               <InputRightElement>
                 <IconButton


### PR DESCRIPTION
## Summary
- Replace plain `Input` fields for addresses with a new `AddressInput` component that truncates long addresses, expands/collapses on click, and renders in monospace
- Make the `IdleSwapCardBody` stack vertically on mobile so the QR code drops below the address details instead of overflowing horizontally
- Widen swap cards from 450/465px to 560px to comfortably fit truncated addresses
- Apply monospace font to destination/refund address inputs in `TradeInput`

## Test plan
- [ ] Verify deposit/refund/receive addresses render in monospace on `/status`
- [ ] Verify long addresses truncate with `head…tail` ellipsis and expand fully on chevron click
- [ ] Verify copy button still copies the full (non-truncated) address
- [ ] On mobile (<768px), confirm QR code drops below the address section in the idle swap card and nothing overflows
- [ ] On desktop (≥768px), confirm QR code remains on the right of the address details
- [ ] Verify destination/refund address inputs in `TradeInput` render entered values in monospace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address fields now feature responsive truncation with expandable/collapse toggle and copy-to-clipboard functionality.

* **Style**
  * Form and status card maximum widths increased from 450px to 560px.
  * Address inputs use a monospace font and unified placeholder styling for improved readability.
  * Status card footer spacing and centering adjusted for better layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->