### PR TITLE
feat: add Tron support (TRX + USDT on Tron)

### DIFF
--- a/src/constants/assets.ts
+++ b/src/constants/assets.ts
@@ -153,6 +153,40 @@ export const initialAssets: Asset[] = [
       'https://rawcdn.githack.com/trustwallet/assets/master/blockchains/solana/info/logo.png',
     networkColor: '#9971d8',
   },
+  {
+    assetId: 'tron:0x2b6653dc/slip44:195',
+    chainId: 'tron:0x2b6653dc',
+    symbol: 'TRX',
+    name: 'Tron',
+    precision: 6,
+    color: '#EB0029',
+    icon: 'https://rawcdn.githack.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+    explorer: 'https://tronscan.org',
+    explorerAddressLink: 'https://tronscan.org/#/address/',
+    explorerTxLink: 'https://tronscan.org/#/transaction/',
+    relatedAssetKey: null,
+    networkName: 'Tron',
+    networkColor: '#EB0029',
+    networkIcon:
+      'https://rawcdn.githack.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+  },
+  {
+    assetId: 'tron:0x2b6653dc/trc20:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+    chainId: 'tron:0x2b6653dc',
+    symbol: 'USDT',
+    name: 'Tether',
+    precision: 6,
+    color: '#24A37B',
+    icon: 'https://rawcdn.githack.com/trustwallet/assets/master/blockchains/tron/assets/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t/logo.png',
+    explorer: 'https://tronscan.org',
+    explorerAddressLink: 'https://tronscan.org/#/address/',
+    explorerTxLink: 'https://tronscan.org/#/transaction/',
+    relatedAssetKey: 'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7',
+    networkName: 'Tron',
+    networkColor: '#EB0029',
+    networkIcon:
+      'https://rawcdn.githack.com/trustwallet/assets/master/blockchains/tron/info/logo.png',
+  },
 ]
 
 export const initialAssetsById = initialAssets.reduce<Record<AssetId, Asset>>((acc, asset) => {

--- a/src/constants/caip.ts
+++ b/src/constants/caip.ts
@@ -26,11 +26,17 @@ export const baseChainId: ChainId = 'eip155:8453'
 
 export const solanaChainId: ChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'
 
+export const tronChainId: ChainId = 'tron:0x2b6653dc'
+
+export const trxAssetId: AssetId = 'tron:0x2b6653dc/slip44:195'
+export const usdtOnTronAssetId: AssetId = 'tron:0x2b6653dc/trc20:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t'
+
 export const CHAIN_NAMESPACE = {
   Evm: 'eip155',
   Utxo: 'bip122',
   CosmosSdk: 'cosmos',
   Solana: 'solana',
+  Tron: 'tron',
 } as const
 
 export const CHAIN_REFERENCE = {
@@ -48,6 +54,7 @@ export const ASSET_NAMESPACE = {
   erc1155: 'erc1155',
   slip44: 'slip44',
   splToken: 'token',
+  trc20: 'trc20',
 } as const
 
 export const ASSET_REFERENCE = {
@@ -55,6 +62,7 @@ export const ASSET_REFERENCE = {
   Ethereum: '60',
   Arbitrum: '60', // evm chain which uses ethereum derivation path as common practice
   Solana: '501',
+  Tron: '195',
 } as const
 
-export const FEE_ASSET_IDS = [ethAssetId, btcAssetId, arbitrumAssetId, solAssetId]
+export const FEE_ASSET_IDS = [ethAssetId, btcAssetId, arbitrumAssetId, solAssetId, trxAssetId]

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,6 +1,6 @@
 import { btcChainId } from '@shapeshiftoss/caip'
 import { PublicKey } from '@solana/web3.js'
-import { solanaChainId } from 'constants/caip'
+import { solanaChainId, tronChainId } from 'constants/caip'
 import debounce from 'lodash/debounce'
 import WAValidator from 'multicoin-address-validator'
 import { isAddress } from 'viem'
@@ -28,6 +28,10 @@ const isValidAddressSync = (address: string, chainId: string): boolean => {
         }
       case btcChainId: {
         const isValid = WAValidator.validate(address, 'BTC')
+        return isValid
+      }
+      case tronChainId: {
+        const isValid = WAValidator.validate(address, 'TRX')
         return isValid
       }
       default:

--- a/src/queries/chainflip/assets.ts
+++ b/src/queries/chainflip/assets.ts
@@ -6,10 +6,12 @@ import {
   ethAssetId,
   flipAssetId,
   solAssetId,
+  trxAssetId,
   usdcAssetId,
   usdcOnArbitrumOneAssetId,
   usdcOnSolanaAssetId,
   usdtAssetId,
+  usdtOnTronAssetId,
 } from 'constants/caip'
 import mirror from 'lodash/invert'
 
@@ -27,6 +29,8 @@ const assetIdToChainflipId: Record<AssetId, string> = {
   [usdcAssetId]: 'usdc.eth',
   [usdcOnSolanaAssetId]: 'usdc.sol',
   [usdtAssetId]: 'usdt.eth',
+  [trxAssetId]: 'trx.tron',
+  [usdtOnTronAssetId]: 'usdt.tron',
 }
 
 // Map Chainflip internal asset IDs to CAIPs

--- a/src/queries/marketData/index.ts
+++ b/src/queries/marketData/index.ts
@@ -6,10 +6,12 @@ import {
   ethAssetId,
   flipAssetId,
   solAssetId,
+  trxAssetId,
   usdcAssetId,
   usdcOnArbitrumOneAssetId,
   usdcOnSolanaAssetId,
   usdtAssetId,
+  usdtOnTronAssetId,
 } from 'constants/caip'
 
 import { reactQueries } from '../react-queries'
@@ -28,6 +30,8 @@ const ASSET_ID_TO_COINGECKO_ID: Record<string, string> = {
   [usdcOnArbitrumOneAssetId]: 'usd-coin',
   [solAssetId]: 'solana',
   [usdcOnSolanaAssetId]: 'usd-coin',
+  [trxAssetId]: 'tron',
+  [usdtOnTronAssetId]: 'tether',
 }
 
 export const findByAssetId = async (assetId: string): Promise<MarketData | null> => {


### PR DESCRIPTION
## Summary

Chainflip recently added native **TRX** (`trx.tron`) and **USDT on Tron** (`usdt.tron`). This wires both as swappable assets.

This app is a swap-only frontend over Chainflip — the user pastes a destination address; no key derivation/signing for the receiving chain. So adding Tron only requires declaring the assets, mapping to Chainflip IDs, validating pasted addresses, and wiring market data.

## Changes

- **`constants/caip.ts`** — `tronChainId`, `trxAssetId`, `usdtOnTronAssetId` constants (+ namespace/reference map entries, `trxAssetId` in `FEE_ASSET_IDS`)
- **`constants/assets.ts`** — TRX + USDT-on-Tron entries in `initialAssets` (precision 6, tronscan explorer, Trust Wallet icons; USDT-Tron links to canonical USDT via `relatedAssetKey` for the network badge)
- **`queries/chainflip/assets.ts`** — map asset IDs to `trx.tron` / `usdt.tron`
- **`lib/validation.ts`** — Tron address validation via `multicoin-address-validator` (`TRX`)
- **`queries/marketData/index.ts`** — coingecko ids `tron` / `tether`

Asset modal, quote, and swap flows are chain-agnostic and pick up the new assets automatically.

## CAIP identifiers

| Asset | assetId |
|-------|---------|
| TRX | `tron:0x2b6653dc/slip44:195` |
| USDT (Tron) | `tron:0x2b6653dc/trc20:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` |

## Testing

- `yarn type-check`, `yarn lint`, `yarn test` (9/9) all pass
- Manual in-app verification (live quote, address validation, icons) still recommended before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced comprehensive Tron blockchain support with TRX cryptocurrency and USDT TRC-20 token assets
  * Enabled Tron address validation for secure transactions
  * Integrated Tron assets with market data and exchange trading infrastructure
  * Users can now manage, view pricing, and trade Tron-based assets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->